### PR TITLE
Change Log should overwrite the default log name

### DIFF
--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -264,14 +264,19 @@ void LogRotateHelper::fileWrite(std::string message) {
 }
 
 std::string LogRotateHelper::changeLogFile(const std::string& directory, const std::string& new_name) {
+    std::cout << "(1) log_prefix_backup_ = **" << log_prefix_backup_ << "**" << std::endl;
     std::string file_name = new_name;
     if (file_name.empty()) {
         std::cout << "no filename" << std::endl;
-       file_name = createLogFileName(log_prefix_backup_);
+        file_name = log_prefix_backup_;
+        std::cout << "Creating new log file with name: " << file_name << std::endl;
+    } else {
+        log_prefix_backup_ = file_name;
+        std::cout << "Saving new log_prefix_backup_ to = **" << log_prefix_backup_ << "**" << std::endl;
     }
 
 
-    std::string prospect_log = directory + file_name;
+    std::string prospect_log = createLogFileName(directory + file_name);
     std::unique_ptr<std::ofstream> log_stream = createLogFile(prospect_log);
     if (nullptr == log_stream) {
         fileWrite("Unable to change log file. Illegal filename or busy? Unsuccessful log name was:" + prospect_log);

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -264,15 +264,12 @@ void LogRotateHelper::fileWrite(std::string message) {
 }
 
 std::string LogRotateHelper::changeLogFile(const std::string& directory, const std::string& new_name) {
-    std::cout << "(1) log_prefix_backup_ = **" << log_prefix_backup_ << "**" << std::endl;
     std::string file_name = new_name;
     if (file_name.empty()) {
         std::cout << "no filename" << std::endl;
         file_name = log_prefix_backup_;
-        std::cout << "Creating new log file with name: " << file_name << std::endl;
     } else {
         log_prefix_backup_ = file_name;
-        std::cout << "Saving new log_prefix_backup_ to = **" << log_prefix_backup_ << "**" << std::endl;
     }
 
 

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -268,10 +268,7 @@ std::string LogRotateHelper::changeLogFile(const std::string& directory, const s
     if (file_name.empty()) {
         std::cout << "no filename" << std::endl;
         file_name = log_prefix_backup_;
-    } else {
-        log_prefix_backup_ = file_name;
     }
-
 
     std::string prospect_log = createLogFileName(directory + file_name);
     std::unique_ptr<std::ofstream> log_stream = createLogFile(prospect_log);
@@ -279,6 +276,7 @@ std::string LogRotateHelper::changeLogFile(const std::string& directory, const s
         fileWrite("Unable to change log file. Illegal filename or busy? Unsuccessful log name was:" + prospect_log);
         return ""; // no success
     }
+    log_prefix_backup_ = file_name;
     addLogFileHeader();
     std::ostringstream ss_change;
 

--- a/logrotate/test/RotateFileTest.cpp
+++ b/logrotate/test/RotateFileTest.cpp
@@ -54,7 +54,7 @@ TEST_F(RotateFileTest, ChangeLogFile) {
       EXPECT_EQ(logfilename, newname);
 
 
-      newname = logrotate.changeLogFile(_directory, "some_new_file.log");
+      newname = logrotate.changeLogFile(_directory, "some_new_file");
       EXPECT_EQ(expected_newname, newname);
 
    } // RAII flush of log
@@ -77,8 +77,27 @@ TEST_F(RotateFileTest, setMaxLogSize) {
 
    exists = Exists(content, first_message_in_new_log);
    EXPECT_TRUE(exists) << "\n\tcontent:" << content << "-\n\tentry: " << gone;
+}
 
+TEST_F(RotateFileTest, setMaxLogSizeAndRotate) {
+   LogRotate logrotate(_filename, _directory);
+   
+   logrotate.changeLogFile(_directory, "new_sink_name");
+   auto logfilename = logrotate.logFileName();
 
+   std::string gone{"Soon to be missing words"};
+   logrotate.save(gone);
+   logrotate.setMaxLogSize(static_cast<int>(gone.size()));
+
+   std::string first_message_in_new_log = "first message";
+   logrotate.save(first_message_in_new_log);
+   
+   auto content = ReadContent(logfilename);
+   auto exists = Exists(content, gone);
+   EXPECT_FALSE(exists) << "\n\tcontent:" << content << "-\n\tentry: " << gone;
+
+   exists = Exists(content, first_message_in_new_log);
+   EXPECT_TRUE(exists) << "\n\tcontent:" << content << "-\n\tentry: " << gone;
 }
 
 


### PR DESCRIPTION
Logs weren't rotating over to the new name if you used ```changeLogName()```, they were rolling over to the original default name.

Added a test for this case as well. 