### PR TITLE
Off by one error in the size required to rotate logs

### DIFF
--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -298,7 +298,7 @@ bool LogRotateHelper::rotateLog() {
         is.seekp(0, std::ios::end);
         int length = is.tellp();
         is.seekp(0, std::ios::beg);
-        if (length > max_log_size_) {
+        if (length >= max_log_size_) {
             std::ostringstream gz_file_name;
             gz_file_name << log_file_with_path_ << ".";
             gz_file_name << g3::localtime_formatted(g3::systemtime_now(), "%Y-%m-%d-%H-%M-%S");

--- a/logrotate/test/RotateFileTest.cpp
+++ b/logrotate/test/RotateFileTest.cpp
@@ -87,6 +87,7 @@ TEST_F(RotateFileTest, setMaxLogSizeAndRotate_ValidNewName) {
    logrotate.changeLogFile(_directory, newFileName);
    auto logfilename = logrotate.logFileName();
    EXPECT_EQ(_directory + newFileName + ".log", logfilename);
+   _filesToRemove.push_back(logfilename);
 
    std::string gone{"Soon to be missing words"};
    logrotate.save(gone);


### PR DESCRIPTION
greater than becomes greater than or equals