### PR TITLE
Rayrapetyan  performance fixes

### DIFF
--- a/logrotate/CMakeLists.txt
+++ b/logrotate/CMakeLists.txt
@@ -23,15 +23,15 @@ INCLUDE_DIRECTORIES(${G3_HEADER_PATH})
 
 #Find all libraries
 
-find_package(Boost COMPONENTS filesystem system regex REQUIRED)
+find_package(Boost COMPONENTS filesystem system REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-find_library(G3LOG g3logger PATHS ${G3_LIBRARY_PATH})
+find_library(G3LOG ${G3LOG_LIBRARY_TYPE} PATHS ${G3_LIBRARY_PATH})
 
 IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
    MESSAGE("")
    MESSAGE("cmake for Clang ")
-   SET(CMAKE_CXX_FLAGS "-Wall -std=c++11 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
+   SET(CMAKE_CXX_FLAGS "-Wall -Werror -std=c++11 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
    IF (${CMAKE_SYSTEM} MATCHES "FreeBSD-([0-9]*)\\.(.*)")
        IF (${CMAKE_MATCH_1} GREATER 9)
            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
@@ -47,7 +47,7 @@ ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
    MESSAGE("")
    MESSAGE("cmake for GCC ")
    SET(PLATFORM_LINK_LIBRIES rt)
-   SET(CMAKE_CXX_FLAGS "-Wall -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP")
+   SET(CMAKE_CXX_FLAGS " -Wall -Werror -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP")
 ENDIF()
 
 
@@ -57,10 +57,17 @@ FILE(GLOB SRC_FILES ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.ipp $
 
 # Setup Library name
 SET(LIBRARY_TO_BUILD g3logrotate)
-
+MESSAGE("BOOST LIBRARIES: ${Boost_LIBRARIES}")
 # Build the library
 INCLUDE_DIRECTORIES(${PROJECT_SRC})
-ADD_LIBRARY(${LIBRARY_TO_BUILD} ${SRC_FILES})
+
+# see Options.cmake
+IF(BUILD_STATIC)
+   ADD_LIBRARY(${LIBRARY_TO_BUILD} ${SRC_FILES})
+ELSE()
+   ADD_LIBRARY(${LIBRARY_TO_BUILD} SHARED ${SRC_FILES})
+ENDIF()
+
 SET(${LIBRARY_TO_BUILD}_VERSION_STRING)
 SET_TARGET_PROPERTIES(${LIBRARY_TO_BUILD} PROPERTIES LINKER_LANGUAGE CXX)
 TARGET_LINK_LIBRARIES(${LIBRARY_TO_BUILD} ${TCMALLOC} ${Boost_LIBRARIES} z ${G3LOG})

--- a/logrotate/CMakeLists.txt
+++ b/logrotate/CMakeLists.txt
@@ -21,12 +21,29 @@ SET(ACTIVE_CPP0xx_DIR "Release")
 INCLUDE (${LogRotate_SOURCE_DIR}/Options.cmake)
 INCLUDE_DIRECTORIES(${G3_HEADER_PATH})
 
-#Find all libraries 
-find_library(z boost_filesystem boost_system boost_regex)
-find_library(G3LOG g3logger_shared PATHS ${G3_LIBRARY_PATH})
+#Find all libraries
 
+find_package(Boost COMPONENTS filesystem system regex REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
 
-IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+find_library(G3LOG g3logger PATHS ${G3_LIBRARY_PATH})
+
+IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+   MESSAGE("")
+   MESSAGE("cmake for Clang ")
+   SET(CMAKE_CXX_FLAGS "-Wall -std=c++11 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
+   IF (${CMAKE_SYSTEM} MATCHES "FreeBSD-([0-9]*)\\.(.*)")
+       IF (${CMAKE_MATCH_1} GREATER 9)
+           set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+           set(PLATFORM_LINK_LIBRIES execinfo)
+       ENDIF()
+   ELSEIF (APPLE)
+       set(PLATFORM_LINK_LIBRIES c++abi)
+   ELSE()
+       set(PLATFORM_LINK_LIBRIES rt c++abi)
+   ENDIF()
+
+ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
    MESSAGE("")
    MESSAGE("cmake for GCC ")
    SET(PLATFORM_LINK_LIBRIES rt)
@@ -43,20 +60,12 @@ SET(LIBRARY_TO_BUILD g3logrotate)
 
 # Build the library
 INCLUDE_DIRECTORIES(${PROJECT_SRC})
-ADD_LIBRARY(${LIBRARY_TO_BUILD} SHARED ${SRC_FILES})
+ADD_LIBRARY(${LIBRARY_TO_BUILD} ${SRC_FILES})
 SET(${LIBRARY_TO_BUILD}_VERSION_STRING)
 SET_TARGET_PROPERTIES(${LIBRARY_TO_BUILD} PROPERTIES LINKER_LANGUAGE CXX)
-TARGET_LINK_LIBRARIES(${LIBRARY_TO_BUILD} ${TCMALLOC} boost_filesystem boost_system boost_regex z ${G3LOG})
+TARGET_LINK_LIBRARIES(${LIBRARY_TO_BUILD} ${TCMALLOC} ${Boost_LIBRARIES} z ${G3LOG})
 
 
 
 # Setup unit tests
 INCLUDE (${LogRotate_SOURCE_DIR}/test/Test.cmake)
-
-
-
-
-
-
-
-

--- a/logrotate/Options.cmake
+++ b/logrotate/Options.cmake
@@ -20,10 +20,10 @@
 
 
 SET(G3_LIBRARY_PATH "" CACHE FILEPATH "Path to g3log libraries")
-IF(EXISTS "${G3_LIBRARY_PATH}/libg3logger_shared.so" )
+IF(EXISTS "${G3_LIBRARY_PATH}/libg3logger.a")
    MESSAGE("SUCCESS lib")
 ELSE()
-  MESSAGE(SEND_ERROR "Can't find g3logger library file in G3_LIBRARY_PATH/libg3logger_shared.so:'${G3_LIBRARY_PATH}/libg3logger_shared.so'. Please set it with '-DG3_LIBRARY_PATH'")
+  MESSAGE(SEND_ERROR "Can't find g3logger library file in G3_LIBRARY_PATH/libg3logger.a:' ${G3_LIBRARY_PATH}'. Please set it with '-DG3_LIBRARY_PATH'")
 ENDIF()
 
 
@@ -32,7 +32,7 @@ SET(G3_HEADER_PATHa "" CACHE FILEPATH "Path to g3log headers")
 IF(EXISTS ${G3_HEADER_PATH}/g3log/g3log.hpp)
    MESSAGE("SUCCESS path")
 ELSE()
-  MESSAGE(FATAL_ERROR "Can't find g3log.hpp at  G3_HEADER_PATH/g3log/g3log.hpp, i.e. '${G3_HEADER_PATH}/g3log/g3log.hpp'. Please set it with '-DG3_HEADER_PATH'")
+  MESSAGE(FATAL_ERROR "Can't find g3log.hpp at G3_HEADER_PATH/g3log/g3log.hpp, i.e. '${G3_HEADER_PATH}/g3log/g3log.hpp'. Please set it with '-DG3_HEADER_PATH'")
 ENDIF()
 
 
@@ -66,4 +66,3 @@ ENDIF()
 
 #MESSAGE("G3_HEADER_PATH = " ${G3_HEADER_PATH})
 #MESSAGE("You can change it with  cmake -DUSE_G3_HEADER_PATH=path_to_headers (i.e. something like /usr/local/include)")
-

--- a/logrotate/Options.cmake
+++ b/logrotate/Options.cmake
@@ -4,65 +4,43 @@
 # =====================================================
 
 
+# SHARED or STATIC library build --- also will re-use this to 
+# use SHARED g3log library or STATIC g3log library
+#
+# example: cmake -DBUILD_STATIC=ON .. 
+option (BUILD_STATIC "Building g3logrotate as static library. Linking with static g3log library" OFF)
+IF (BUILD_STATIC) 
+  SET(G3LOG_LIBRARY_TYPE g3logger)
+  SET(G3LOG_LIBRARY_NAME libg3logger.a)
+  MESSAGE("'OPTION: cmake -DBUILD_STATIC=ON'\nLinking statically with g3log. Creating static library for g3logrotate")
+ELSE()
+  SET(G3LOG_LIBRARY_TYPE g3logger_shared)
+  SET(G3LOG_LIBRARY_NAME libg3logger_shared.so)
+  MESSAGE("'OPTION cmake -DBUILD_STATIC=ON'\nLinking dynamically with g3log. Creating dynamic library for g3logrotate")
+ENDIF()
+
+
+
 # Override the default path for g3log library
 #example1:  cmake -DG3_LIBRARY_PATH="/usr/local/probe/lib"
 #example2:  cmake -DG3_LIBRARY_PATH="/home/kjell/Github/g3log/build"
-#http://stackoverflow.com/questions/12984181/specifying-include-directories-on-the-cmake-command-line
-
 #
-#set(YOURLIB_INCLUDE_DIR "" CACHE FILEPATH "Path to yourlib includes")
-#
-#if(NOT YOURLIB_INCLUDE_DIR/header.h)
-#  message(SEND_ERROR "Can't find header.h in ${YOURLIB_INCLUDE_DIR})
-#endif()
-#
-#include_directories(${YOURLIB_INCLUDE_DIR})
-
-
 SET(G3_LIBRARY_PATH "" CACHE FILEPATH "Path to g3log libraries")
-IF(EXISTS "${G3_LIBRARY_PATH}/libg3logger.a")
+IF(EXISTS "${G3_LIBRARY_PATH}/${G3LOG_LIBRARY_NAME}")
    MESSAGE("SUCCESS lib")
 ELSE()
-  MESSAGE(SEND_ERROR "Can't find g3logger library file in G3_LIBRARY_PATH/libg3logger.a:' ${G3_LIBRARY_PATH}'. Please set it with '-DG3_LIBRARY_PATH'")
+  MESSAGE(SEND_ERROR "Can't find g3logger library file in G3_LIBRARY_PATH/${G3LOG_LIBRARY_NAME}:' ${G3_LIBRARY_PATH}'. Please set it with '-DG3_LIBRARY_PATH' \nExample run could be something like:\ncmake -DG3_HEADER_PATH=/home/X/ws/g3log/src/ -DG3_LIBRARY_PATH=/home/X/ws/g3log/build -DADD_LOGROTATE_UNIT_TEST=ON")
 ENDIF()
 
 
-
-SET(G3_HEADER_PATHa "" CACHE FILEPATH "Path to g3log headers")
+# Override the default include path to g3log library
+#example1:  cmake -DUSE_G3_HEADER_PATH="/usr/local/probe/include/"
+#example2:  cmake -DUSE_G3_HEADER_PATH="/home/kjell/Github/g3log/src"
+#
+SET(G3_HEADER_PATH "" CACHE FILEPATH "Path to g3log headers")
 IF(EXISTS ${G3_HEADER_PATH}/g3log/g3log.hpp)
    MESSAGE("SUCCESS path")
 ELSE()
-  MESSAGE(FATAL_ERROR "Can't find g3log.hpp at G3_HEADER_PATH/g3log/g3log.hpp, i.e. '${G3_HEADER_PATH}/g3log/g3log.hpp'. Please set it with '-DG3_HEADER_PATH'")
+  MESSAGE(FATAL_ERROR "Can't find g3log.hpp at G3_HEADER_PATH/g3log/g3log.hpp, i.e. '${G3_HEADER_PATH}/g3log/g3log.hpp'. Please set it with '-DG3_HEADER_PATH'. \nExample run could be something like:\ncmake -DG3_HEADER_PATH=/home/X/ws/g3log/src/ -DG3_LIBRARY_PATH=/home/X/ws/g3log/build -DADD_LOGROTATE_UNIT_TEST=ON")
 ENDIF()
 
-
-
-#option (USE_G3_LIBRARY_PATH
-#       "Find g3log libraries by this path instead of default" OFF)
-#SET(G3_LIBRARY_PATH_DEFAULT "/usr/local/lib/")
-#IF (${USE_G3PATH_LIBRARY} )
-#   SET(G3_LIBRARY_PATH ${USE_G3_LIBRARY_PATH})
-#ELSE()
-#   SET(G3_LIBRARY_PATH ${G3_LIBRARY_PATH_DEFAULT})
-#ENDIF()
-
-#MESSAGE("G3_LIBRARY_PATH = " ${G3_LIBRARY_PATH})
-#MESSAGE("You can change it with  cmake -DUSE_G3_LIBRARY_PATH=path_to_libraries (i.e. something like /usr/local/lib)")
-
-
-
-# Override the default path for looking up g3log headers 
-#example1:  cmake -DUSE_G3_HEADER_PATH="/usr/local/probe/include/"
-#example2:  cmake -DUSE_G3_HEADER_PATH="/home/kjell/Github/g3log/src"
-#option (USE_G3_HEADER_PATH
-#       "Find g3log headers by this path instead of default" OFF)
-#SET(G3_HEADER_PATH_DEFAULT "/usr/local/include/")
-#
-#IF (${USE_G3_HEADER_PATH} ) 
-#   SET(G3_HEADER_PATH ${USE_G3_HEADER_PATH})
-#ELSE()
-#   SET(G3_HEADER_PATH ${G3_HEADER_PATH_DEFAULT})
-#ENDIF()
-
-#MESSAGE("G3_HEADER_PATH = " ${G3_HEADER_PATH})
-#MESSAGE("You can change it with  cmake -DUSE_G3_HEADER_PATH=path_to_headers (i.e. something like /usr/local/include)")

--- a/logrotate/packaging/g3logrotate.spec
+++ b/logrotate/packaging/g3logrotate.spec
@@ -39,7 +39,7 @@ fi
 
 rm -f  CMakeCache.txt
 
-%{install_root}/bin/cmake -DCMAKE_CXX_COMPILER_ARG1:STRING=' -fPIC -Ofast -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,%{install_root}/lib -Wl,-rpath -Wl,%{install_root}/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DG3_LIBRARY_PATH=%{install_root}/lib -DG3_HEADER_PATH=%{install_root}/include -DCMAKE_CXX_COMPILER=%{install_root}/bin/g++ ..
+%{install_root}/bin/cmake -DCMAKE_CXX_COMPILER_ARG1:STRING=' -Wall -Werror -fPIC -Ofast -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,%{install_root}/lib -Wl,-rpath -Wl,%{install_root}/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DG3_LIBRARY_PATH=%{install_root}/lib -DG3_HEADER_PATH=%{install_root}/include -DCMAKE_CXX_COMPILER=%{install_root}/bin/g++ ..
 
 make -j6
 ./UnitTestRunner

--- a/logrotate/src/LogRotate.cpp
+++ b/logrotate/src/LogRotate.cpp
@@ -48,6 +48,30 @@ void LogRotate::setMaxArchiveLogCount(int max_size) {
 }
 
 /**
+* Flush policy: Default is every single time (i.e. policy of 1). 
+*
+* If the system logs A LOT then it is likely better to allow for the system to buffer and write
+* all the entries at once. 
+* 
+* 0: System decides, potentially very long time
+* 1....N: Flush logs every n entry 
+*/
+void LogRotate::setFlushPolicy(size_t flush_policy){
+	pimpl_->setFlushPolicy(flush_policy);
+}
+
+/**
+* Force flush of log entries. This should normally be policed with the @ref setFlushPolicy
+* but is great for unit testing and if there are special circumstances where you want to see
+* the logs faster than the flush_policy
+*/
+void LogRotate::flush(){
+	pimpl_->flush();
+}
+
+
+
+/**
  * Set the max log size in bytes.
  * @param max_file_size
  */

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -290,7 +290,6 @@ void LogRotateHelper::fileWrite(std::string message) {
 
 void LogRotateHelper::flushPolicy() {
     if (0 == flush_policy_) return;
-
     if (0 == --flush_policy_counter_) {
         flush();
         flush_policy_counter_ = flush_policy_;
@@ -299,7 +298,9 @@ void LogRotateHelper::flushPolicy() {
 
 
 void LogRotateHelper::setFlushPolicy(size_t flush_policy) {
+   flush();
    flush_policy_ = flush_policy;
+   flush_policy_counter_ = flush_policy;
 }
 
 
@@ -382,6 +383,7 @@ void LogRotateHelper::setLogSizeCounter() {
     is.seekp(0, std::ios::end);
     cur_log_size_ = is.tellp();
     is.seekp(0, std::ios::beg);
+    flush_policy_counter_ = flush_policy_;
 }
 
 

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -207,6 +207,7 @@ struct LogRotateHelper {
     steady_time_point steady_start_time_;
     int max_log_size_;
     int max_archive_log_count_;
+    int cur_log_size_;
 
 
 
@@ -221,7 +222,7 @@ LogRotateHelper::LogRotateHelper(const std::string& log_prefix, const std::strin
     , steady_start_time_(std::chrono::steady_clock::now()) { // TODO: ha en timer function steadyTimer som har koll pÃ¥ start
     log_prefix_backup_ = prefixSanityFix(log_prefix);
     max_log_size_ = 524288000;
-    max_archive_log_count_ = 10;
+    max_archive_log_count_ = 10;    
     if (!isValidFilename(log_prefix_backup_)) {
         std::cerr << "g3log: forced abort due to illegal log prefix [" << log_prefix << "]" << std::endl;
         abort();
@@ -232,6 +233,11 @@ LogRotateHelper::LogRotateHelper(const std::string& log_prefix, const std::strin
     outptr_ = createLogFile(log_file_with_path_);
     assert((nullptr != outptr_) && "cannot open log file at startup");
     addLogFileHeader();
+
+    std::ofstream& is(filestream());
+    is.seekp(0, std::ios::end);
+    cur_log_size_ = is.tellp();
+    is.seekp(0, std::ios::beg);
 }
 
 /**
@@ -260,25 +266,30 @@ LogRotateHelper::~LogRotateHelper() {
 void LogRotateHelper::fileWrite(std::string message) {
     rotateLog();
     std::ofstream& out(filestream());
-    out << message << std::flush;
+    out << message;// << std::flush;
+    cur_log_size_ += message.size();
 }
 
 std::string LogRotateHelper::changeLogFile(const std::string& directory, const std::string& new_name) {
     std::string file_name = new_name;
     if (file_name.empty()) {
-        std::cout << "no filename" << std::endl;
-        file_name = log_prefix_backup_;
+       // std::cout << "no filename" << std::endl;
+       file_name = createLogFileName(log_prefix_backup_);
     }
 
-    std::string prospect_log = createLogFileName(directory + file_name);
+
+    std::string prospect_log = directory + file_name;
     std::unique_ptr<std::ofstream> log_stream = createLogFile(prospect_log);
     if (nullptr == log_stream) {
         fileWrite("Unable to change log file. Illegal filename or busy? Unsuccessful log name was:" + prospect_log);
         return ""; // no success
     }
-    log_prefix_backup_ = file_name;
     addLogFileHeader();
-    std::ostringstream ss_change;
+
+    std::ofstream& is(filestream());
+    is.seekp(0, std::ios::end);
+    cur_log_size_ = is.tellp();
+    is.seekp(0, std::ios::beg);
 
     std::string old_log = log_file_with_path_;
     log_file_with_path_ = prospect_log;
@@ -294,11 +305,9 @@ std::string LogRotateHelper::changeLogFile(const std::string& directory, const s
 bool LogRotateHelper::rotateLog() {
     std::ofstream& is(filestream());
     if (is.is_open()) {
-        // get length of file:
-        is.seekp(0, std::ios::end);
-        int length = is.tellp();
-        is.seekp(0, std::ios::beg);
-        if (length >= max_log_size_) {
+        if (cur_log_size_ > max_log_size_) {
+            is << std::flush;
+
             std::ostringstream gz_file_name;
             gz_file_name << log_file_with_path_ << ".";
             gz_file_name << g3::localtime_formatted(g3::systemtime_now(), "%Y-%m-%d-%H-%M-%S");
@@ -361,4 +370,3 @@ std::string LogRotateHelper::logFileName() {
 void LogRotateHelper::addLogFileHeader() {
     filestream() << header();
 }
-

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -273,17 +273,17 @@ void LogRotateHelper::fileWrite(std::string message) {
 std::string LogRotateHelper::changeLogFile(const std::string& directory, const std::string& new_name) {
     std::string file_name = new_name;
     if (file_name.empty()) {
-       // std::cout << "no filename" << std::endl;
-       file_name = createLogFileName(log_prefix_backup_);
+        //std::cout << "no filename" << std::endl;
+        file_name = log_prefix_backup_;
     }
 
-
-    std::string prospect_log = directory + file_name;
+    std::string prospect_log = createLogFileName(directory + file_name);
     std::unique_ptr<std::ofstream> log_stream = createLogFile(prospect_log);
     if (nullptr == log_stream) {
         fileWrite("Unable to change log file. Illegal filename or busy? Unsuccessful log name was:" + prospect_log);
         return ""; // no success
     }
+    log_prefix_backup_ = file_name;
     addLogFileHeader();
 
     std::ofstream& is(filestream());

--- a/logrotate/src/g3sinks/LogRotate.h
+++ b/logrotate/src/g3sinks/LogRotate.h
@@ -33,6 +33,10 @@ class LogRotate {
     std::string changeLogFile(const std::string& log_directory, const std::string& new_name="");
     std::string logFileName();
     void setMaxArchiveLogCount(int max_size);
+    void setFlushPolicy(size_t flush_policy); // 0: never (system auto flush), 1 ... N: every n times
+    void flush();
+
+
     void setMaxLogSize(int max_file_size);
 
   private:

--- a/logrotate/test/RotateFileTest.h
+++ b/logrotate/test/RotateFileTest.h
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <cstring>
 #include <cerrno>
+#include <cstdlib>
 
 class RotateFileTest : public ::testing::Test {
  public:
@@ -35,6 +36,13 @@ class RotateFileTest : public ::testing::Test {
             std::cout << "error deleting: " << filename << ": " <<  std::strerror(errno) << std::endl;
          }
       }
+
+      std::string removeTgz_1 = std::string("rm -f ") + _directory  + "g3sink_rotatefile_test*.gz";
+      system(removeTgz_1.c_str());
+
+      std::string removeTgz_2 = std::string("rm -f ") + _directory  + "new_sink_name*.gz";
+      system(removeTgz_2.c_str());
+      
    }
 
    std::string _filename;

--- a/logrotate/test/RotateTestHelper.cpp
+++ b/logrotate/test/RotateTestHelper.cpp
@@ -24,7 +24,9 @@ namespace RotateTestHelper {
    std::string ReadContent(const std::string filename) {
       std::ifstream readIn(filename.c_str(), std::ios::in | std::ios::binary);
       if (readIn) {
-         std::shared_ptr<void> raii(nullptr, [&](void*) {readIn.close(); std::cout << "closed file: " << filename << std::endl;});
+         std::shared_ptr<void> raii(nullptr, [&](void*) {
+            readIn.close(); //std::cout << __FILE__ << ":" << __LINE__ << " closed file: " << filename << std::endl;
+            });
 
          std::string contents;
          readIn.seekg(0, std::ios::end);

--- a/logrotate/test/Test.cmake
+++ b/logrotate/test/Test.cmake
@@ -3,24 +3,30 @@
 #  2015, April 30, @author Kjell.Hedstrom
 # =====================================================
 
+option (ADD_LOGROTATE_UNIT_TEST "logrotate unit tests" OFF)
 
+IF (ADD_LOGROTATE_UNIT_TEST)
 
-set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
-set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
-MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
-include_directories(${GTEST_INCLUDE_DIRECTORIES})
-add_library(gtest_170_lib ${GTEST_DIR}/src/gtest-all.cc)
-set_target_properties(gtest_170_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
-enable_testing(true)
-include_directories(test)
-file(GLOB TEST_SRC_FILES "test/*.cpp" "test/*.h" "test/*.hpp")
-set(TestRunner UnitTestRunner)
+    set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
+    set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
+    MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
+    include_directories(${GTEST_INCLUDE_DIRECTORIES})
+    add_library(gtest_170_lib ${GTEST_DIR}/src/gtest-all.cc)
+    set_target_properties(gtest_170_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
+    enable_testing(true)
+    include_directories(test)
+    file(GLOB TEST_SRC_FILES "test/*.cpp" "test/*.h" "test/*.hpp")
+    set(TestRunner UnitTestRunner)
 
-# build the unit tests   
-add_executable(${TestRunner} ${DIR_3RDPARTY}/test_main.cpp ${TEST_SRC_FILES} )
-set_target_properties(${TestRunner} PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_TR1_TUPLE=0")
-set_target_properties(${TestRunner} PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
-set_target_properties(${TestRunner} PROPERTIES COMPILE_FLAGS "-isystem -pthread ")
-target_link_libraries(${TestRunner} ${LIBRARY_TO_BUILD} ${G3LOG} gtest_170_lib -lstdc++ ${TCMALLOC}  ${PLATFORM_LINK_LIBRIES} -Wl,-rpath,. -Wl,-rpath,${G3_LIBRARY_PATH}  -Wl,-rpath,${G3_LIBRARY_PATH}/../lib64 )
+    # build the unit tests   
+    add_executable(${TestRunner} ${DIR_3RDPARTY}/test_main.cpp ${TEST_SRC_FILES} )
+    set_target_properties(${TestRunner} PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_TR1_TUPLE=0")
+    set_target_properties(${TestRunner} PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
+    set_target_properties(${TestRunner} PROPERTIES COMPILE_FLAGS "-isystem -pthread ")
+    target_link_libraries(${TestRunner} ${LIBRARY_TO_BUILD} ${G3LOG} gtest_170_lib -lstdc++ ${TCMALLOC}  ${PLATFORM_LINK_LIBRIES} -Wl,-rpath,. -Wl,-rpath,${G3_LIBRARY_PATH}  -Wl,-rpath,${G3_LIBRARY_PATH}/../lib64 )
 
-MESSAGE("library to build ${LIBRARY_TO_BUILD}")
+    MESSAGE("library to build ${LIBRARY_TO_BUILD}")
+
+ELSE() 
+  MESSAGE("-DADD_LOGROTATE_UNIT_TEST=OFF") 
+ENDIF (ADD_LOGROTATE_UNIT_TEST)


### PR DESCRIPTION
Will also move my comments from his (https://github.com/KjellKod/g3sinks/pull/15) pull request to this one

1. flush policy (0: system flush,  1 .... N: flush every n times)

2. cmake configurable to create a static library or dynamic library.  It will link with g3log in the same manner (static for static, dynamic for dynamic)

3. avoids (thanks to rayrapet) to recalculate the file size each time. Instead an internal counter is used to decide when to log rotate