### PR TITLE
Enable make package; make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The ZLIB library must be installed for the logrotate to be able to compress the 
 in Ubuntu it can be installed with `sudo apt-get install zlib1g-dev`. Please see your specific platform for details or go to the [zlib page](http://www.zlib.net/)
 
 
+### Building with unit tests added
 ```
 cd g3sinks
 cd 3rdparty
@@ -48,10 +49,26 @@ cd ..
 cd logrotate
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON -DG3_LIBRARY_PATH=/usr/local/lib -DG3_HEADER_PATH=/usr/local/include -DBOOST_ROOT=/usr/local ..
-make 
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON -DG3_LIBRARY_PATH=/usr/local/lib -DG3_HEADER_PATH=/usr/local/include -DBOOST_ROOT=/usr/local -DADD_LOGROTATE_UNIT_TEST=ON ..
+make -j
+```
+
+### Executing the unit tests
+```
+./UnitTestRunneer
+```
+
+### Installing
+```
 sudo make install
 ```
+
+Alternative on Debian systems
+```
+make package
+sudo dpkg -i g3LogRotate-<package_version>Linux.deb
+```
+
 
 
 # Say Thanks

--- a/logrotate/CMakeLists.txt
+++ b/logrotate/CMakeLists.txt
@@ -86,6 +86,16 @@ MESSAGE("Libraries, g3log: ${G3LOG}")
 MESSAGE("Libraries, boost: ${Boost_LIBRARIES}")
 MESSAGE("Libraries, zlib: ${ZLIB_LIBRARIES}")
 
-
 # Setup unit tests
 INCLUDE (${LogRotate_SOURCE_DIR}/test/Test.cmake)
+
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+   FILE(GLOB HEADER_FILES ${PROJECT_SRC}/g3sinks/*.h)
+   # ==========================================================================
+   #   Package handling is done AFTER all other CMake setup
+   #   usage:   make package
+   #   Check the output result and install accordingly.
+   # ==========================================================================
+   INCLUDE (${LogRotate_SOURCE_DIR}/CPackLists.txt)
+ENDIF()
+

--- a/logrotate/CPackLists.txt
+++ b/logrotate/CPackLists.txt
@@ -1,0 +1,91 @@
+#  INSTALL( TARGETS g3LogRotate
+#           ARCHIVE
+#           LIBRARY DESTINATION lib/g3sinks
+#           COMPONENT libraries)
+
+#  INSTALL( FILES ${HEADER_FILES}
+#           DESTINATION include
+#           COMPONENT headers)
+
+
+SET(MAJOR_VERSION 1)
+IF (NOT DEFINED ${VERSION})
+   MESSAGE("Extracting git software version")
+   execute_process(COMMAND bash "-c" "git rev-list --branches HEAD | wc -l | tr -d ' ' | tr -d '\n'" OUTPUT_VARIABLE GIT_VERSION)
+   SET(MINOR_VERSION ${GIT_VERSION})
+   SET(BUILD_NUMBER 0)
+   SET(VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_NUMBER}) 
+ENDIF()
+MESSAGE("Software Version: ${VERSION}")
+
+IF (NOT DEFINED ${CPACK_INSTALL_PREFIX})
+   SET(CPACK_INSTALL_PREFIX "/usr/local")
+ENDIF()
+
+SET(CPACK_PACKAGE_NAME g3LogRotate)
+SET(CPACK_PACKAGE_VERSION_MAJOR ${MAJOR_VERSION})
+SET(CPACK_PACKAGE_VERSION_MINOR ${MINOR_VERSION})
+SET(CPACK_PACKAGE_VERSION_PATCH ${BUILD_NUMBER})
+SET(CPACK_PACKAGE_DESCRIPTION "Logging sinks compatible with the g3log library.
+                              g3LogRotate. Rotate logs accoording to size limits. Old logs are compressed and 
+                              eventually deleted. 
+                              The g3LogRotate is a public domain dedication.  License: http://unlicense.org
+                              Repository: https://github.com/KjellKod/g3sinks")
+SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})
+SET(CPACK_PACKAGE_CONTACT "Kjell Hedstrom hedstrom@kjellkoc.cc")
+SET(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SRC}/../LICENSE)
+SET(CPACK_PACKAGE_VENDOR "KjellKod")
+SET(CMAKE_INSTALL_HEADERDIR ${CMAKE_INSTALL_HEADERDIR}/g3sinks)
+
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+   MESSAGE("\nTo create installation package: ")
+   MESSAGE("make package")
+ENDIF()
+MESSAGE("\nOption to install using 'sudo make install")
+MESSAGE("Installation locations: ")
+MESSAGE("====================")
+MESSAGE("Headers: ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_HEADERDIR}/g3sinks")
+MESSAGE("Library : ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+MESSAGE("Headers to be installed: ${HEADER_FILES}")
+MESSAGE("header locaton: ${CMAKE_INSTALL_HEADERDIR}")
+
+MESSAGE("For more information please see https://github.com/KjellKod/g3sinks/logrotate/CPackLists.txt")
+MESSAGE("To install: sudo dpkg -i g3logrotate-***Linux.deb")
+MESSAGE("To list files in install package: sudo dpkg --contents g3logrotate-***Linux.deb")
+MESSAGE("To list installed files: sudo dpkg -L g3logrotate")
+MESSAGE("To remove: sudo dpkg -r g3logrotate")
+MESSAGE("To remove: sudo dpkg -r g3logrotate")
+
+#  NOTE: to change installation locations you can use the settings below
+#  examples:
+#  CPACK_INSTALL_PREFIX
+#  CMAKE_INSTALL_HEADERDIR
+#  CMAKE_INSTALL_LIBDIR
+
+SET(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output dir for libraries")
+SET(CMAKE_INSTALL_HEADERDIR include CACHE PATH "Output dir for headers")
+
+
+INSTALL( TARGETS g3logrotate 
+        ARCHIVE DESTINATION ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)
+
+INSTALL( FILES ${HEADER_FILES}
+          DESTINATION ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_HEADERDIR}
+          COMPONENT headers)
+
+INSTALL( FILES ${PROJECT_SOURCE_DIR}/cmake/g3logrotateConfig.cmake
+          DESTINATION ${CPACK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/g3logrotate)
+
+SET(CPACK_COMPONENTS_ALL libraries headers)
+SET(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "g3logrotate libraries")
+SET(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "g3logrotate C++ headers")
+
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+   SET(CPACK_GENERATOR "DEB")
+   SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "KjellKod")
+ENDIF()
+
+
+INCLUDE(CPack)

--- a/logrotate/cmake/g3logrotateConfig.cmake
+++ b/logrotate/cmake/g3logrotateConfig.cmake
@@ -1,0 +1,36 @@
+#.rst:
+# Findg3LogRotate
+# -------
+#
+# Find libg3logrotate, A sink for the g3log library (https://github.com/KjellKod/g3log)
+# g3logrotate is a public domain dedication, http://unlicense.org
+#
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``g3LOGROTATE_INCLUDE_DIRS``
+#   where to find LogRotate.h  LogRotateUtility.h  LogRotateWithFilter.h
+
+# ``G3LOGROTATE_LIBRARIES``
+#   the libraries to link against to use libLogRotate.h  LogRotateUtility.h  LogRotateWithFilter.h.
+#   that includes libgMurMurHash library files.
+
+# ``G3LOGROTATE_FOUND``
+#   If false, do not try to use g3logrotate.
+
+include(FindPackageHandleStandardArgs)
+
+find_path(G3LOGROTATE_INCLUDE_DIR ${PROJECT_SRC}/LogRotate.h  ${PROJECT_SRC}/LogRotateUtility.h  ${PROJECT_SRC}/LogRotateWithFilter.h)
+
+find_library(G3LOGROTATE_LIBRARY
+            NAMES libg3logrotate g3logrotate)
+
+find_package_handle_standard_args(G3LOGROTATE  DEFAULT_MSG
+            G3LOGROTATE_INCLUDE_DIR G3LOGROTATE_LIBRARY)
+
+mark_as_advanced(G3LOGROTATE_INCLUDE_DIR  G3LOGROTATE_LIBRARY)
+
+set( G3LOGROTATE_LIBRARIES ${ G3LOGROTATE_LIBRARY})
+set( G3LOGROTATE_INCLUDE_DIRS ${ G3LOGROTATE_INCLUDE_DIR})

--- a/logrotate/test/RotateFileTest.h
+++ b/logrotate/test/RotateFileTest.h
@@ -41,10 +41,10 @@ class RotateFileTest : public ::testing::Test {
       }
 
       std::string removeTgz_1 = std::string("rm -f ") + _directory  + "g3sink_rotatefile_test*.gz";
-      system(removeTgz_1.c_str());
+      EXPECT_EQ(0, system(removeTgz_1.c_str()));
 
       std::string removeTgz_2 = std::string("rm -f ") + _directory  + "new_sink_name*.gz";
-      system(removeTgz_2.c_str());
+      EXPECT_EQ(0, system(removeTgz_2.c_str()));
 
    }
 


### PR DESCRIPTION
With this pull request it is even easier to install g3sinks

Example of installation
```
cd g3sinks
cd 3rdparty
unzip gtest-1.7.0.zip
cd ..
cd logrotate
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON -DG3_LIBRARY_PATH=/usr/local/lib -DG3_HEADER_PATH=/usr/local/include -DBOOST_ROOT=/usr/local -DADD_LOGROTATE_UNIT_TEST=ON ..
make -j
```

### Executing the unit tests
```
./UnitTestRunneer
```

### Installing
```
sudo make install
```

Alternative on Debian systems
```
make package
sudo dpkg -i g3LogRotate-<package_version>Linux.deb
