### PR TITLE
Updated sinks already to work with the new g3log time format

### DIFF
--- a/logrotate/CMakeLists.txt
+++ b/logrotate/CMakeLists.txt
@@ -87,7 +87,7 @@ FILE(GLOB SRC_FILES ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.ipp $
 IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
    MESSAGE("")
    MESSAGE("cmake for Clang ")
-   SET(CMAKE_CXX_FLAGS "-Wall -Werror -std=c++11 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
+   SET(CMAKE_CXX_FLAGS "-Wall -Werror -std=c++14 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
    IF (${CMAKE_SYSTEM} MATCHES "FreeBSD-([0-9]*)\\.(.*)")
        IF (${CMAKE_MATCH_1} GREATER 9)
            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")

--- a/logrotate/src/LogRotateHelper.ipp
+++ b/logrotate/src/LogRotateHelper.ipp
@@ -118,7 +118,8 @@ void LogRotateHelper::setMaxLogSize(int max_size) {
 
 LogRotateHelper::~LogRotateHelper() {
    std::ostringstream ss_exit;
-   ss_exit << "\ng3log file shutdown at: " << g3::localtime_formatted(g3::systemtime_now(), g3::internal::time_formatted) << "\n\n";
+    auto now = std::chrono::system_clock::now(); 
+   ss_exit << "\ng3log file shutdown at: " << g3::localtime_formatted(now, g3::internal::time_formatted) << "\n\n";
    filestream() << ss_exit.str() << std::flush;
 }
 
@@ -193,28 +194,27 @@ bool LogRotateHelper::rotateLog() {
 
       if (cur_log_size_ > max_log_size_) {
          is << std::flush;
-
-            std::ostringstream gz_file_name;
-            gz_file_name << log_file_with_path_ << ".";
-            gz_file_name << g3::localtime_formatted(g3::systemtime_now(), "%Y-%m-%d-%H-%M-%S");
-            gz_file_name << ".gz";
-            if (!createCompressedFile(log_file_with_path_, gz_file_name.str())) {
-                fileWriteWithoutRotate("Failed to compress log!");
-                return false;
-            }
-            is.close();
-            if (remove(log_file_with_path_.c_str()) == -1) {
-                fileWriteWithoutRotate("Failed to remove old log!");
-            }
-            changeLogFile(log_directory_);
-            std::ostringstream ss;
-            ss << "Log rotated Archived file name: " << gz_file_name.str().c_str();
-            fileWriteWithoutRotate(ss.str());
-            ss.clear();
-            ss.str("");
-            ss << log_prefix_backup_ << ".log";
-            expireArchives(log_directory_, ss.str(), max_archive_log_count_);
-
+         std::ostringstream gz_file_name;
+         gz_file_name << log_file_with_path_ << ".";
+         auto now = std::chrono::system_clock::now(); 
+         gz_file_name << g3::localtime_formatted(now, "%Y-%m-%d-%H-%M-%S");
+         gz_file_name << ".gz";
+         if (!createCompressedFile(log_file_with_path_, gz_file_name.str())) {
+             fileWriteWithoutRotate("Failed to compress log!");
+             return false;
+         }
+         is.close();
+         if (remove(log_file_with_path_.c_str()) == -1) {
+             fileWriteWithoutRotate("Failed to remove old log!");
+         }
+         changeLogFile(log_directory_);
+         std::ostringstream ss;
+         ss << "Log rotated Archived file name: " << gz_file_name.str().c_str();
+         fileWriteWithoutRotate(ss.str());
+         ss.clear();
+         ss.str("");
+         ss << log_prefix_backup_ << ".log";
+         expireArchives(log_directory_, ss.str(), max_archive_log_count_);
          return true;
       }
    }

--- a/logrotate/src/LogRotateUtility.cpp
+++ b/logrotate/src/LogRotateUtility.cpp
@@ -75,8 +75,10 @@ namespace  LogRotateUtility {
    /// @return the file header
    std::string header() {
       std::ostringstream ss_entry;
-      //  Day Month Date Time Year: is written as "%a %b %d %H:%M:%S %Y" and formatted output as : Wed Sep 19 08:28:16 2012
-      ss_entry << "\ng3log: created log file at: " << g3::localtime_formatted(g3::systemtime_now(), "%a %b %d %H:%M:%S %Y") << "\n";
+      //  Day Month Date Time Year: is written as "%a %b %d %H:%M:%S %Y" 
+     //   and formatted output as : Wed Sep 19 08:28:16 2012
+     auto now = std::chrono::system_clock::now();      
+     ss_entry << "\ng3log: created log file at: " << g3::localtime_formatted(now, "%a %b %d %H:%M:%S %Y") << "\n";
       return ss_entry.str();
    }
 

--- a/logrotate/src/LogRotateWithFilter.cpp
+++ b/logrotate/src/LogRotateWithFilter.cpp
@@ -16,8 +16,7 @@
 // helper function to create an logging sink with filter
 std::unique_ptr<LogRotateWithFilter> LogRotateWithFilter::CreateLogRotateWithFilter(std::string filename, std::string directory, std::vector<LEVELS> filter) {
     auto logRotatePtr = std2::make_unique<LogRotate>(filename, directory);
-    auto logWithFilter = std2::make_unique<LogRotateWithFilter>(std::move(logRotatePtr), filter);
-    return std::move(logWithFilter);
+    return std2::make_unique<LogRotateWithFilter>(std::move(logRotatePtr), filter);
 }
 
 


### PR DESCRIPTION
Updated sinks already to work with the new g3log time format. 

This still doesn't solve it for Clang however as I get the following error message
```
Linking CXX shared library libg3logrotate.dylib
Undefined symbols for architecture x86_64:
  "g3::localtime_formatted(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      LogRotateHelper::~LogRotateHelper() in LogRotate.cpp.o
      LogRotateHelper::rotateLog() in LogRotate.cpp.o
      LogRotateUtility::header() in LogRotateUtility.cpp.o
  "g3::LogMessage::toString() const", referenced from:
      LogRotateWithFilter::save(g3::MoveOnCopy<g3::LogMessage>) in LogRotateWithFilter.cpp.o
ld: symbol(s) not found for architecture x86_64
```