### PR TITLE
fix mktime memory leak

### DIFF
--- a/logrotate/src/LogRotateUtility.cpp
+++ b/logrotate/src/LogRotateUtility.cpp
@@ -97,7 +97,7 @@ namespace  LogRotateUtility {
          if (regex_match(suffix, date_match, date_regex)) {
             if (date_match.size() == 2) {
                std::string date = date_match[1].str();
-               struct tm tm;
+               struct tm tm = {0};
                time_t t;
                if (strptime(date.c_str(), "%Y-%m-%d-%H-%M-%S", &tm) == nullptr) {
                   return false;


### PR DESCRIPTION
see this:
https://stackoverflow.com/questions/9037631/valgrind-complaining-about-mktime-is-that-my-fault

when using valgrind, we also meet this:
```
==4717== Conditional jump or move depends on uninitialised value(s)
==4717==    at 0x5814DDB: __mktime_internal (in /usr/lib64/libc-2.17.so)
==4717==    by 0xEFFB6F: LogRotateUtility::getDateFromFileName(std::string const&, std::string const&, long&) (in /root/run/mychain_standalone)
==4717==    by 0xEFFE69: LogRotateUtility::expireArchives(std::string const&, std::string const&, unsigned long) (in /root/run/mychain_standalone)
==4717==    by 0xEFCF3A: LogRotateHelper::rotateLog() (in /root/run/mychain_standalone)
==4717==    by 0xEFD980: LogRotateHelper::fileWrite(std::string) (in /root/run/mychain_standalone)
==4717==    by 0xEFE30F: LogRotate::save(std::string) (in /root/run/mychain_standalone)
==4717==    by 0xE9B638: void std::__invoke_impl<void, void (LogRotate::* const&)(std::string), LogRotate*&, std::string>(std::__invoke_memfun_deref, void (LogRotate::* const&)(std::string), LogRotate*&, std::string&&) (functional:227)
==4717==    by 0xE9B4FA: std::result_of<void (LogRotate::* const&(LogRotate*&, std::string&&))(std::string)>::type std::__invoke<void (LogRotate::* const&)(std::string), LogRotate*&, std::string>(void (LogRotate::* const&)(std::string), LogRotate*&, std::string&&) (functional:251)
==4717==    by 0xE9B31C: decltype (__invoke((*this)._M_pmf, (forward<LogRotate*&>)({parm#1}), (forward<std::string>)({parm#1}))) std::_Mem_fn_base<void (LogRotate::*)(std::string), true>::operator()<LogRotate*&, std::string>(LogRotate*&, std::string&&) const (functional:604)
==4717==    by 0xE9AEF8: void std::_Bind<std::_Mem_fn<void (LogRotate::*)(std::string)> (LogRotate*, std::_Placeholder<1>)>::__call<void, std::string&&, 0ul, 1ul>(std::tuple<std::string&&>&&, std::_Index_tuple<0ul, 1ul>) (functional:934)
==4717==    by 0xE9A880: void std::_Bind<std::_Mem_fn<void (LogRotate::*)(std::string)> (LogRotate*, std::_Placeholder<1>)>::operator()<std::string, void>(std::string&&) (functional:993)
==4717==    by 0xE9A261: std::_Function_handler<void (std::string), std::_Bind<std::_Mem_fn<void (LogRotate::*)(std::string)> (LogRotate*, std::_Placeholder<1>)> >::_M_invoke(std::_Any_data const&, std::string&&) (functional:1731)
```