### PR TITLE
Added Windows CI for Tracelogging using Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,21 @@ image:
 clone_folder: c:\projects\source
 build_script:
 - cmd: >-
-    cd tracelogging
+    cd ..
+    
+    git clone https://github.com/KjellKod/g3log.git
+
+    cd g3log
+
+    mkdir build
+
+    cd build
+
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=c:\usr\local -DCMAKE_INSTALL_PREFIX=c:\usr\local -DG3_SHARED_LIB=OFF -DG3_SHARED_RUNTIME=ON ..
+
+    cmake --build . --target INSTALL --config Release
+    
+    cd ..\source\tracelogging
 
     mkdir build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+image:
+  - Visual Studio 2017
+clone_folder: c:\projects\source
+build_script:
+- cmd: >-
+    cd tracelogging
+    mkdir build
+    cd build
+    
+    cmake c:\projects\source -G "Visual Studio 15"
+    
+    cmake --build . --config "Debug"
+
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=c:\usr\local -DCMAKE_INSTALL_PREFIX=c:\usr\local ..
+    cmake --build . --target INSTALL --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,11 @@ clone_folder: c:\projects\source
 build_script:
 - cmd: >-
     cd tracelogging
+
     mkdir build
+
     cd build
 
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=c:\usr\local -DCMAKE_INSTALL_PREFIX=c:\usr\local -G "Visual Studio 15" ..
+
     cmake --build . --target INSTALL --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ build_script:
 
     cd g3log
 
-    git fetch origin pull/312/head:pull/312
-
-    git checkout pull/312 
-
     mkdir build
 
     cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ build_script:
 
     cd g3log
 
+    git fetch origin pull/312/head:pull/312
+
+    git checkout pull/312 
+
     mkdir build
 
     cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,6 @@ build_script:
     cd tracelogging
     mkdir build
     cd build
-    
-    cmake c:\projects\source -G "Visual Studio 15"
-    
-    cmake --build . --config "Debug"
 
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=c:\usr\local -DCMAKE_INSTALL_PREFIX=c:\usr\local ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=c:\usr\local -DCMAKE_INSTALL_PREFIX=c:\usr\local -G "Visual Studio 15" ..
     cmake --build . --target INSTALL --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ image:
 clone_folder: c:\projects\source
 build_script:
 - cmd: >-
-    cd ..
+    cd c:\projects
     
     git clone https://github.com/KjellKod/g3log.git
 
@@ -21,7 +21,7 @@ build_script:
 
     cmake --build . --target INSTALL --config Release
     
-    cd ..\source\tracelogging
+    cd c:\projects\source\tracelogging
 
     mkdir build
 

--- a/tracelogging/README.md
+++ b/tracelogging/README.md
@@ -15,7 +15,7 @@ In order for this to work properly, g3log will need to be installed and the loca
 
 When building g3log for UWP, the following options are required
 ```
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=<prefix path> -DCMAKE_INSTALL_PREFIX=<install path> -DG3LOG_UWP_BUILD=ON -DG3_SHARED_LIB=OFF -DG3_SHARED_RUNTIME=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=<prefix path> -DCMAKE_INSTALL_PREFIX=<install path> -DG3_SHARED_LIB=OFF -DG3_SHARED_RUNTIME=ON ..
 ```
 
 Kernel32.lib is also a required dependency


### PR DESCRIPTION
I was able to get CI running with Appveyor but it relies on pull request #312 of g3log so we'll probably want to wait until that pull request has been accepted into the g3log baseline and I'll update the appveyor.yml appropriately.  I also haven't developed any tests so this is build only.

Something for you to look at is the way I'm cloning g3log to install it.  The first time I did this, it asked me to provide my github password which put a bit of a bad taste in my mouth so this may not be the best approach.  Another option I thought of was to make g3log an external project so it pulls down as part of executing the Tracelogging cmake if it isn't already installed.  I'm not sure if this would eliminate the need for the password or really change anything substantially but would like your thoughts on the best approach.