### PR TITLE
join-free sink methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - os: linux
       dist: xenial
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.3
 
 
 compiler:

--- a/common/g3sinksUtils.hpp
+++ b/common/g3sinksUtils.hpp
@@ -8,9 +8,8 @@
 * ============================================================================*/
 
 
+#pragma once
 
-#ifndef g3DeepCopyTypes
-#define g3DeepCopyTypes
 /*
  
  These deep copy types have been introduced to make it easier to
@@ -24,8 +23,9 @@
   - wait for the thread (join it) with std::future .get()
 
  */
-#include <functional>
 #include <cstring>
+#include <functional>
+#include <memory>
 
 namespace g3
 {
@@ -36,13 +36,22 @@ class DltrStr
 public:
     DltrStr() = delete;
     // the deleter accompanies the memory block to enable it beeing freed in the library (using a different heap, as on Windows):
-    DltrStr(const char * content) {size_t len = strlen(content); _content = std::unique_ptr<char [], std::function<void(char[])>>(new char[len + 1], [](char b[]){ delete[](b);} ); memcpy(_content.get(), content, len+1); };
-    DltrStr(const std::string& content) {size_t len = content.length(); _content = std::unique_ptr<char [], std::function<void(char[])>>(new char[len + 1], [](char b[]){ delete[](b);} ); memcpy(_content.get(), content.c_str(), len+1); };
+    DltrStr(const char * content) {
+        size_t len = strlen(content);
+        _content = std::shared_ptr<char []>(new char[len + 1], [](char b[]){ delete[](b);} );
+        memcpy(_content.get(), content, len+1); };
+        
+    DltrStr(const std::string& content) {
+        size_t len = content.length();
+        _content = std::shared_ptr<char []>(new char[len + 1], [](char b[]){ delete[](b);} );
+        memcpy(_content.get(), content.c_str(), len+1); };
+        
     const char *c_str() {return _content.get();};
+    
 private:
     std::shared_ptr<char []> _content;
 };
 
 }
 
-#endif
+

--- a/common/g3sinksUtils.hpp
+++ b/common/g3sinksUtils.hpp
@@ -36,8 +36,8 @@ class DltrStr
 public:
     DltrStr() = delete;
     // the deleter accompanies the memory block to enable it beeing freed in the library (using a different heap, as on Windows):
-    DltrStr(const char * content) {size_t len = strlen(content); _content = std::unique_ptr<char [], std::function<void(char*)>>(new char[len + 1], [](char* b){ delete[](b);} ); memcpy(_content.get(), content, len+1); };
-    DltrStr(const std::string& content) {size_t len = content.length(); _content = std::unique_ptr<char [], std::function<void(char*)>>(new char[len + 1], [](char* b){ delete[](b);} ); memcpy(_content.get(), content.c_str(), len+1); };
+    DltrStr(const char * content) {size_t len = strlen(content); _content = std::unique_ptr<char [], std::function<void(char[])>>(new char[len + 1], [](char b[]){ delete[](b);} ); memcpy(_content.get(), content, len+1); };
+    DltrStr(const std::string& content) {size_t len = content.length(); _content = std::unique_ptr<char [], std::function<void(char[])>>(new char[len + 1], [](char b[]){ delete[](b);} ); memcpy(_content.get(), content.c_str(), len+1); };
     const char *c_str() {return _content.get();};
 private:
     std::shared_ptr<char []> _content;

--- a/common/g3sinksUtils.hpp
+++ b/common/g3sinksUtils.hpp
@@ -38,18 +38,18 @@ public:
     // the deleter accompanies the memory block to enable it beeing freed in the library (using a different heap, as on Windows):
     DltrStr(const char * content) {
         size_t len = strlen(content);
-        _content = std::shared_ptr<char []>(new char[len + 1], [](char b[]){ delete[](b);} );
+        _content = std::shared_ptr<char>(new char[len + 1], [](char *b){ delete[](b);} );
         memcpy(_content.get(), content, len+1); };
         
     DltrStr(const std::string& content) {
         size_t len = content.length();
-        _content = std::shared_ptr<char []>(new char[len + 1], [](char b[]){ delete[](b);} );
+        _content = std::shared_ptr<char>(new char[len + 1], [](char *b){ delete[](b);} );
         memcpy(_content.get(), content.c_str(), len+1); };
         
     const char *c_str() {return _content.get();};
     
 private:
-    std::shared_ptr<char []> _content;
+    std::shared_ptr<char> _content;
 };
 
 }

--- a/common/g3sinksUtils.hpp
+++ b/common/g3sinksUtils.hpp
@@ -1,0 +1,48 @@
+/** ==========================================================================
+* 2020 Joel Stienlet
+* this file is part of g3log by KjellKod.cc 
+*
+* This code is PUBLIC DOMAIN to use at your own risk and comes
+* with no warranties. This code is yours to share, use and modify with no
+* strings attached and no restrictions or obligations.
+* ============================================================================*/
+
+
+
+#ifndef g3DeepCopyTypes
+#define g3DeepCopyTypes
+/*
+ 
+ These deep copy types have been introduced to make it easier to
+ call sink methods with dynamically allocated data, without 
+ having to wait for the worker thread to finish.
+ They work together with the "NoJn"(No thread Join)-suffixed variants of
+ the corresponding sink methods.
+ 
+ Alternatively, you can:
+  - use static data
+  - wait for the thread (join it) with std::future .get()
+
+ */
+#include <functional>
+#include <cstring>
+
+namespace g3
+{
+
+// RAII string type with its deleter (Dltr) included to cross library boundaries 
+class DltrStr
+{
+public:
+    DltrStr() = delete;
+    // the deleter accompanies the memory block to enable it beeing freed in the library (using a different heap, as on Windows):
+    DltrStr(const char * content) {size_t len = strlen(content); _content = std::unique_ptr<char [], std::function<void(char*)>>(new char[len + 1], [](char* b){ delete[](b);} ); memcpy(_content.get(), content, len+1); };
+    DltrStr(const std::string& content) {size_t len = content.length(); _content = std::unique_ptr<char [], std::function<void(char*)>>(new char[len + 1], [](char* b){ delete[](b);} ); memcpy(_content.get(), content.c_str(), len+1); };
+    const char *c_str() {return _content.get();};
+private:
+    std::shared_ptr<char []> _content;
+};
+
+}
+
+#endif

--- a/logrotate/CMakeLists.txt
+++ b/logrotate/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(DIR_3RDPARTY ${LogRotate_SOURCE_DIR}/../3rdparty)
 
 MESSAGE(" PROJECT_SRC = : ${PROJECT_SRC}")
 INCLUDE_DIRECTORIES(${PROJECT_SRC})
+INCLUDE_DIRECTORIES(${PROJECT_SRC}/../../common)
 SET(ACTIVE_CPP0xx_DIR "Release")
 
 
@@ -147,6 +148,7 @@ INCLUDE (${LogRotate_SOURCE_DIR}/test/Test.cmake)
 #
 IF( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
    FILE(GLOB HEADER_FILES ${PROJECT_SRC}/g3sinks/*.h)
+   list(APPEND HEADER_FILES ${PROJECT_SRC}/../../common/g3sinksUtils.hpp)
    INCLUDE (${LogRotate_SOURCE_DIR}/CPackLists.txt)
 ENDIF()
 

--- a/logrotate/src/LogRotate.cpp
+++ b/logrotate/src/LogRotate.cpp
@@ -35,6 +35,12 @@ std::string LogRotate::changeLogFile(const std::string& log_directory, const std
     return pimpl_->changeLogFile(log_directory, new_name);
 }
 
+// wraps LogRotate::changeLogFile() to use strings with deleter,
+// making it unnecessary to join the worker thread to control the lifetime of string arguments.
+g3::DltrStr LogRotate::changeLogFileNoJn(g3::DltrStr log_directory, g3::DltrStr new_name) {
+    return g3::DltrStr(changeLogFile(log_directory.c_str(), new_name.c_str()));
+}
+
 /// @return the current file name to write to
 std::string LogRotate::logFileName() {
     return pimpl_->logFileName();

--- a/logrotate/src/g3sinks/LogRotate.h
+++ b/logrotate/src/g3sinks/LogRotate.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <memory>
 
-
+#include "g3sinksUtils.hpp"
 
 struct LogRotateHelper;
 
@@ -43,7 +43,8 @@ class LogRotate {
     void setMaxLogSize(int max_file_size_in_bytes);
     int getMaxLogSize();
 
-    
+    // Alternative methods releaving C-string argument lifetime constraints:
+    g3::DltrStr changeLogFileNoJn(g3::DltrStr log_directory, g3::DltrStr new_name);
 
   private:
     std::unique_ptr<LogRotateHelper> pimpl_;

--- a/logrotate/src/g3sinks/LogRotate.h
+++ b/logrotate/src/g3sinks/LogRotate.h
@@ -11,10 +11,10 @@
 
 #pragma once
 
+#include "g3sinksUtils.hpp"
+
 #include <string>
 #include <memory>
-
-#include "g3sinksUtils.hpp"
 
 struct LogRotateHelper;
 
@@ -32,6 +32,9 @@ class LogRotate {
 
     void save(std::string logEnty);
     std::string changeLogFile(const std::string& log_directory, const std::string& new_name="");
+    // Alternative method releaving C-string argument lifetime constraints:
+    g3::DltrStr changeLogFileNoJn(g3::DltrStr log_directory, g3::DltrStr new_name);
+    
     std::string logFileName();
     void setMaxArchiveLogCount(int max_size);
     int getMaxArchiveLogCount();
@@ -43,8 +46,6 @@ class LogRotate {
     void setMaxLogSize(int max_file_size_in_bytes);
     int getMaxLogSize();
 
-    // Alternative methods releaving C-string argument lifetime constraints:
-    g3::DltrStr changeLogFileNoJn(g3::DltrStr log_directory, g3::DltrStr new_name);
 
   private:
     std::unique_ptr<LogRotateHelper> pimpl_;

--- a/syslog/CMakeLists.txt
+++ b/syslog/CMakeLists.txt
@@ -31,6 +31,9 @@ target_include_directories(g3log_syslog
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
       $<INSTALL_INTERFACE:include>
     )
+target_include_directories(g3log_syslog PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
+)
 SET_TARGET_PROPERTIES(g3log_syslog PROPERTIES 
                       LINKER_LANGUAGE CXX
                       OUTPUT_NAME g3log_syslog
@@ -61,10 +64,11 @@ install(EXPORT g3log_syslogTargets
 	NAMESPACE G3::
 	DESTINATION lib/cmake
 	)
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
-	DESTINATION include
-	FILES_MATCHING
-	PATTERN *.h*
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/g3log/syslogsink.hpp"
+	DESTINATION include/g3sinks
+	)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../common/g3sinksUtils.hpp"
+	DESTINATION include/g3sinks
 	)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("g3log_syslogVersion.cmake"

--- a/syslog/src/g3log/syslogsink.hpp
+++ b/syslog/src/g3log/syslogsink.hpp
@@ -26,10 +26,11 @@
  *
  */
 #pragma once
-#include <map>
-#include <string>
 
 #include "g3sinksUtils.hpp"
+
+#include <map>
+#include <string>
 
 namespace g3
 {
@@ -49,18 +50,18 @@ public:
     
     void setFormatter(LogDetailsFunc func) { _log_details_func = func; }
     void setLogHeader(const char* change) { _header = change; }
+    // Alternative method releaving C-string argument lifetime constraints:
+    void setLogHeaderNoJn(g3::DltrStr change) { _header = change.c_str(); }
     void echoToStderr(); // enables the Linux extension LOG_PERROR
 
     void setIdentity(const char* id) { _identity = id; }
+    // Alternative method releaving C-string argument lifetime constraints:
+    void setIdentityNoJn(g3::DltrStr id) { _identity = id.c_str(); }
     void setFacility(int facility) { _facility = facility; }
     void setOption(int option) { _option = option; }
     void setLevelMap(std::map<int, int> const& m);
 
     void setLevel(LogLevel level, int syslevel);
-
-    // Alternative methods releaving C-string argument lifetime constraints:
-    void setLogHeaderNoJn(g3::DltrStr change) { _header = change.c_str(); }
-    void setIdentityNoJn(g3::DltrStr id) { _identity = id.c_str(); }
     
 private:
     LogDetailsFunc _log_details_func;

--- a/syslog/src/g3log/syslogsink.hpp
+++ b/syslog/src/g3log/syslogsink.hpp
@@ -29,6 +29,7 @@
 #include <map>
 #include <string>
 
+#include "g3sinksUtils.hpp"
 
 namespace g3
 {
@@ -57,6 +58,10 @@ public:
 
     void setLevel(LogLevel level, int syslevel);
 
+    // Alternative methods releaving C-string argument lifetime constraints:
+    void setLogHeaderNoJn(g3::DltrStr change) { _header = change.c_str(); }
+    void setIdentityNoJn(g3::DltrStr id) { _identity = id.c_str(); }
+    
 private:
     LogDetailsFunc _log_details_func;
     std::map<int, int> _levelMap;


### PR DESCRIPTION
some small changes to address [issue 75](https://github.com/KjellKod/g3sinks/issues/75)
(avoid joining the thread when passing string arguments to sink methods)
I finally created a new class for a custom-string type that includes its deleter (for remark 3) so that it can be deleted on the same heap as it was allocated.
As this class is common to all sinks, I put it in a new "common" directory.
I tested my "NoJn" methods in my own code, I didn't add the unit tests here yet, because CMakeLists.txt in syslog doesn't seem to include the tests(?), I have to investigate that first.