### PR TITLE
new snippet: filelog with open file descriptor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@ option (BUILD_STATIC "Building sinks as static libraries. Linking with static g3
 
 add_subdirectory(syslog)
 add_subdirectory(logrotate)
-
+add_subdirectory(snippets)

--- a/scripts/buildAndRunTests.sh
+++ b/scripts/buildAndRunTests.sh
@@ -69,3 +69,9 @@ cd build/syslog/
 ./example/syslog_g3log_example || true
 echo "FINISHED SYSLOG EXAMPLE"
 
+cd $pwd
+cd build/snippets/
+./g3log_snippets_file_example
+echo "FINISHED FILE DESCRIPTOR EXAMPLE"
+
+

--- a/snippets/CMakeLists.txt
+++ b/snippets/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.2 )
+
+# Copied from syslog's cmakelists:
+# search for g3log
+find_package(g3logger REQUIRED)
+# add the missing target if needed
+if (NOT TARGET g3logger)
+    add_library(g3logger SHARED IMPORTED)
+    find_package(Threads REQUIRED)
+    set_target_properties(g3logger PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${G3LOG_INCLUDE_DIRS}"
+        IMPORTED_LOCATION "${G3LOG_LIBRARY}"
+        IMPORTED_LINK_INTERFACE_LIBRARIES  Threads::Threads
+        )
+endif()
+
+
+add_executable(g3log_snippets_file_example test_FileLog.cpp)
+
+SET_TARGET_PROPERTIES(g3log_snippets_file_example PROPERTIES 
+                      LINKER_LANGUAGE CXX
+                      OUTPUT_NAME g3log_snippets_file_example
+                      CLEAN_DIRECT_OUTPUT 1
+                      CXX_STANDARD 14
+                      CXX_STANDARD_REQUIRED YES
+                      CXX_EXTENSIONS NO
+                      )
+
+
+
+target_link_libraries(g3log_snippets_file_example g3logger)
+
+
+
+

--- a/snippets/FileLogSink.hpp
+++ b/snippets/FileLogSink.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <g3log/logmessage.hpp>
+#include <string>
+#include <unistd.h>
+#include <cstring>
+
+namespace g3{
+
+class FileLogSink {
+public:
+  FileLogSink(int fileDesc, bool close_by_sink): fd(fileDesc), Close_fd(close_by_sink) {};
+  ~FileLogSink() {
+       sync();
+       if(Close_fd && (fd >= 0)) close(fd);};
+  
+  void Rotate(int newFileDesc, bool close_by_sink) {
+      int oldfd = fd;
+      fd = newFileDesc;
+      sync();
+      if(Close_fd && (oldfd >= 0)) close(oldfd);
+      Close_fd = close_by_sink;
+     }
+  
+  void ReceiveLogMessage(g3::LogMessageMover logEntry) {
+     std::string data = logEntry.get().toString();
+     write(fd, data.c_str(), strlen(data.c_str()) );
+     write(fd, "\n", 2 );
+   }
+  
+  void sync() {fsync(fd);};
+  
+private:
+    int fd;
+    bool Close_fd;
+};
+} // g3

--- a/snippets/README.markdown
+++ b/snippets/README.markdown
@@ -9,4 +9,5 @@ A simple example where the log is colored differently depending on what
 logging level it comes with. The color example is for Linux xterm
 .Code snippet: [colored cout](ColorCoutSink.hpp)
 
-
+## File Log
+A simple file logger, with the specificity that it logs to an open file descriptor passed by the user. This may solve specific corner cases where only file descriptors are available. Ex: log to shared memory (fd returned by memfd_create()). Or when file opening may be tricky, for example in a [setuid process](http://www.cis.syr.edu/~wedu/Teaching/cis643/LectureNotes_New/Race_Condition.pdf).

--- a/snippets/test_FileLog.cpp
+++ b/snippets/test_FileLog.cpp
@@ -1,0 +1,61 @@
+//
+// g++ test_FileLog.cpp -lg3logger -lpthread
+//
+#include <g3log/g3log.hpp>
+#include <g3log/logworker.hpp>
+#include "FileLogSink.hpp"
+#include <iostream>
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <sys/mman.h>
+
+void content_to_stderr(int fd)
+{
+ssize_t dataSize;
+ssize_t usefulBufSize = 1234;
+char buf[usefulBufSize+1];
+std::cerr << "buffer contents:" << std::endl;
+lseek(fd, 0, SEEK_SET);
+do{
+    dataSize = read(fd, buf, usefulBufSize);
+    if(dataSize > 0) {
+        buf[dataSize] = 0;
+        std::cerr << buf;
+       }
+  }while(dataSize > 0);
+}
+
+int new_mem_fd(const char *name)
+{
+int fd = memfd_create(name, MFD_CLOEXEC);
+if(fd == -1) {
+    std::cerr << "ERROR: unable to create a memory mapped file." << std::endl;
+    exit(1);
+   }
+return fd;
+}
+
+int main(int argc, char**argv) {   
+int fd1 = new_mem_fd("memfile_1");
+std::unique_ptr<g3::LogWorker> logworker{ g3::LogWorker::createLogWorker() };
+auto sinkHandle = logworker->addSink(std::make_unique<g3::FileLogSink>(fd1, false),
+                                    &g3::FileLogSink::ReceiveLogMessage);
+
+initializeLogging(logworker.get());
+LOG(INFO) << "This content is written to the first memory file descriptor";
+sleep(1); // TODO: wait for the logger to finish, in a cleaner way...
+int fd2 = new_mem_fd("memfile_2");
+std::future<void> to_wait = sinkHandle->call(&g3::FileLogSink::Rotate, fd2, true);
+to_wait.wait();
+content_to_stderr(fd1);
+close(fd1);
+
+LOG(INFO) << "This content is written to the second memory file descriptor";
+sleep(1); // TODO: wait for the logger to finish, in a cleaner way...
+to_wait = sinkHandle->call(&g3::FileLogSink::sync);
+to_wait.wait();
+content_to_stderr(fd2);
+close(fd2);
+return 0;
+}


### PR DESCRIPTION
As included in the readme markdown: A simple file logger snippet, with the specificity that it logs to an open file descriptor passed by the user. This may solve specific corner cases where only file descriptors are available. Ex: log to shared memory (fd returned by memfd_create()). Or when file opening may be tricky and you want to do it manually, for example in a [setuid process](http://www.cis.syr.edu/~wedu/Teaching/cis643/LectureNotes_New/Race_Condition.pdf).