### PR TITLE
builds snippet "logging to file descriptor" test on mac os with memfd…

### DIFF
--- a/scripts/buildAndRunTests.sh
+++ b/scripts/buildAndRunTests.sh
@@ -69,10 +69,10 @@ cd build/syslog/
 ./example/syslog_g3log_example || true
 echo "FINISHED SYSLOG EXAMPLE"
 
-if [ "$(uname)" != "Darwin" ]; then
-   cd $pwd
-   cd build/snippets/
-   ./g3log_snippets_file_example
-   echo "FINISHED FILE DESCRIPTOR EXAMPLE"
-fi
+
+cd $pwd
+cd build/snippets/
+./g3log_snippets_file_example
+echo "FINISHED FILE DESCRIPTOR EXAMPLE"
+
 

--- a/snippets/CMakeLists.txt
+++ b/snippets/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.2 )
 
 # Copied from syslog's cmakelists:
 # search for g3log
-if (NOT ${APPLE})
+# if (NOT ${APPLE})
+#    
    find_package(g3logger REQUIRED)
    # add the missing target if needed
    if (NOT TARGET g3logger)
@@ -14,8 +15,14 @@ if (NOT ${APPLE})
            IMPORTED_LINK_INTERFACE_LIBRARIES  Threads::Threads
            )
    endif()
+   
+   check_include_file("sys/mman.h" HAVE_MMAN)
+   check_include_file("sys/memfd.h" HAVE_MEMFD)
+   CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+   
    add_executable(g3log_snippets_file_example test_FileLog.cpp)
 
+   
    SET_TARGET_PROPERTIES(g3log_snippets_file_example PROPERTIES 
                          LINKER_LANGUAGE CXX
                          OUTPUT_NAME g3log_snippets_file_example
@@ -24,9 +31,9 @@ if (NOT ${APPLE})
                          CXX_STANDARD_REQUIRED YES
                          CXX_EXTENSIONS NO
                          )
-
+   target_include_directories(g3log_snippets_file_example PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
    target_link_libraries(g3log_snippets_file_example g3logger)
-endif()
+# endif()
 
 
 

--- a/snippets/config.h.in
+++ b/snippets/config.h.in
@@ -1,0 +1,3 @@
+
+#cmakedefine HAVE_MMAN
+#cmakedefine HAVE_MEMFD


### PR DESCRIPTION
following pr #82  suggestion: emulate memfd when not available + checks which headers are available on linux
