### PR TITLE
add option to disable installing g3sinks for projects embedding

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -22,3 +22,5 @@ option(CHOICE_SINK_SNIPPETS "Build the syslog sink" ON)
 if(CHOICE_BUILD_TESTS)
   enable_testing()
 endif()
+
+option(CHOICE_INSTALL_G3SINKS "Enable installation of g3sinks. (Projects embedding g3sinks may want to turn this OFF.)" ON)

--- a/sink_logrotate/CMakeLists.txt
+++ b/sink_logrotate/CMakeLists.txt
@@ -51,33 +51,34 @@ endif()
 
 
 
-# INSTALLATION 
-# ===================================================
-install(TARGETS 
-           g3logrotate
-        EXPORT 
-            g3logrotateTargets
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        INCLUDES DESTINATION include)
+if ( CHOICE_INSTALL_G3SINKS )
+    # INSTALLATION 
+    # ===================================================
+    install(TARGETS 
+               g3logrotate
+            EXPORT 
+                g3logrotateTargets
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+            INCLUDES DESTINATION include)
+    
+    install(EXPORT g3logrotateTargets
+      NAMESPACE G3::
+      DESTINATION lib/cmake/g3sinks
+      )
+    
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+      DESTINATION include
+      FILES_MATCHING
+      PATTERN *.h*
+      )
 
-install(EXPORT g3logrotateTargets
-  NAMESPACE G3::
-  DESTINATION lib/cmake/g3sinks
-  )
-
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN *.h*
-  )
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("g3logrotateVersion.cmake"
-  VERSION ${VERSION}
-  COMPATIBILITY AnyNewerVersion
-  )
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3logrotateVersion.cmake"
-  DESTINATION lib/cmake/g3sinks
-  )
-
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file("g3logrotateVersion.cmake"
+      VERSION ${VERSION}
+      COMPATIBILITY AnyNewerVersion
+      )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3logrotateVersion.cmake"
+      DESTINATION lib/cmake/g3sinks
+      )
+endif()

--- a/sink_snippets/CMakeLists.txt
+++ b/sink_snippets/CMakeLists.txt
@@ -19,22 +19,24 @@ if(TRACELOGGING_SINK_ERROR)
 endif()
 
 
-# HEADER ONLY INSTALLATION
-# ===================================================
-install(
-  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN *.h
-  PATTERN "${FILELOG_EXCLUDE_FILE}" EXCLUDE
-  PATTERN "${TRACELOGGING_EXCLUDE_FILE}" EXCLUDE
-  PATTERN "${COLOREDCOUT_EXCLUDE_FILE}" EXCLUDE
-  )
+if ( CHOICE_INSTALL_G3SINKS )
+    # HEADER ONLY INSTALLATION
+    # ===================================================
+    install(
+      DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+      DESTINATION include
+      FILES_MATCHING
+      PATTERN *.h
+      PATTERN "${FILELOG_EXCLUDE_FILE}" EXCLUDE
+      PATTERN "${TRACELOGGING_EXCLUDE_FILE}" EXCLUDE
+      PATTERN "${COLOREDCOUT_EXCLUDE_FILE}" EXCLUDE
+      )
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  "g3snippetsVersion.cmake"
-  VERSION ${VERSION}
-  COMPATIBILITY AnyNewerVersion)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3snippetsVersion.cmake"
-        DESTINATION lib/cmake/g3sinks)
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+      "g3snippetsVersion.cmake"
+      VERSION ${VERSION}
+      COMPATIBILITY AnyNewerVersion)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3snippetsVersion.cmake"
+            DESTINATION lib/cmake/g3sinks)
+endif()

--- a/sink_syslog/CMakeLists.txt
+++ b/sink_syslog/CMakeLists.txt
@@ -44,32 +44,34 @@ target_include_directories(g3syslog
         $<INSTALL_INTERFACE:include>    
     )
 
-# INSTALLATION 
-# ===================================================
-install(TARGETS 
-           g3syslog
-	      EXPORT 
-            g3syslogTargets
-	      ARCHIVE DESTINATION lib
-	      LIBRARY DESTINATION lib
-	      INCLUDES DESTINATION include)
+if ( CHOICE_INSTALL_G3SINKS )
+    # INSTALLATION 
+    # ===================================================
+    install(TARGETS 
+               g3syslog
+    	      EXPORT 
+                g3syslogTargets
+    	      ARCHIVE DESTINATION lib
+    	      LIBRARY DESTINATION lib
+    	      INCLUDES DESTINATION include)
+    
+    install(EXPORT g3syslogTargets
+    	NAMESPACE G3::
+    	DESTINATION lib/cmake/g3sinks
+    	)
+    
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+    	DESTINATION include
+    	FILES_MATCHING
+    	PATTERN *.h*
+    	)
 
-install(EXPORT g3syslogTargets
-	NAMESPACE G3::
-	DESTINATION lib/cmake/g3sinks
-	)
-
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-	DESTINATION include
-	FILES_MATCHING
-	PATTERN *.h*
-	)
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("g3syslogVersion.cmake"
-	VERSION ${VERSION}
-	COMPATIBILITY AnyNewerVersion
-	)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3syslogVersion.cmake"
-	DESTINATION lib/cmake/g3sinks
-	)
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file("g3syslogVersion.cmake"
+    	VERSION ${VERSION}
+    	COMPATIBILITY AnyNewerVersion
+    	)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3syslogVersion.cmake"
+    	DESTINATION lib/cmake/g3sinks
+    	)
+endif()


### PR DESCRIPTION
This is modeled off the work done in https://github.com/KjellKod/g3log/pull/333

Signed-off-by: Ben Magistro <koncept1@gmail.com>

----

I've been using this with logrotate but have not tested with the other sinks, do not anticipate any issues