### PR TITLE
Fix duplicate clean targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,14 +102,14 @@ endif()
 message(
   STATUS
     "\n
-  =====================CLEAN IT ============================
+  ===================== CLEAN IT ============================
   ===========================================================
-  Please use 'make clean-cmake' before next cmake generation.
-  It is a good idea to purge your build directory of CMake
-  generated cache files
+  Please use 'make g3sinks-clean-cmake' before next cmake
+  generation. It is a good idea to purge your build directory
+  of CMake generated cache files
   ===========================================================
        ")
-add_custom_target(clean-cmake COMMAND ${CMAKE_COMMAND} -P
+add_custom_target(g3sinks-clean-cmake COMMAND ${CMAKE_COMMAND} -P
                                       ${g3sinks_SOURCE_DIR}/CleanAll.cmake)
 
 # print all CHOIC options. Ref Options.cmake

--- a/Options.cmake
+++ b/Options.cmake
@@ -22,3 +22,5 @@ option(CHOICE_SINK_SNIPPETS "Build the syslog sink" ON)
 if(CHOICE_BUILD_TESTS)
   enable_testing()
 endif()
+
+option(CHOICE_INSTALL_G3SINKS "Enable installation of g3sinks. (Projects embedding g3sinks may want to turn this OFF.)" ON)

--- a/sink_logrotate/CMakeLists.txt
+++ b/sink_logrotate/CMakeLists.txt
@@ -51,33 +51,34 @@ endif()
 
 
 
-# INSTALLATION 
-# ===================================================
-install(TARGETS 
-           g3logrotate
-        EXPORT 
-            g3logrotateTargets
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        INCLUDES DESTINATION include)
+if ( CHOICE_INSTALL_G3SINKS )
+    # INSTALLATION 
+    # ===================================================
+    install(TARGETS 
+               g3logrotate
+            EXPORT 
+                g3logrotateTargets
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+            INCLUDES DESTINATION include)
+    
+    install(EXPORT g3logrotateTargets
+      NAMESPACE G3::
+      DESTINATION lib/cmake/g3sinks
+      )
+    
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+      DESTINATION include
+      FILES_MATCHING
+      PATTERN *.h*
+      )
 
-install(EXPORT g3logrotateTargets
-  NAMESPACE G3::
-  DESTINATION lib/cmake/g3sinks
-  )
-
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN *.h*
-  )
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("g3logrotateVersion.cmake"
-  VERSION ${VERSION}
-  COMPATIBILITY AnyNewerVersion
-  )
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3logrotateVersion.cmake"
-  DESTINATION lib/cmake/g3sinks
-  )
-
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file("g3logrotateVersion.cmake"
+      VERSION ${VERSION}
+      COMPATIBILITY AnyNewerVersion
+      )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3logrotateVersion.cmake"
+      DESTINATION lib/cmake/g3sinks
+      )
+endif()

--- a/sink_snippets/CMakeLists.txt
+++ b/sink_snippets/CMakeLists.txt
@@ -19,22 +19,24 @@ if(TRACELOGGING_SINK_ERROR)
 endif()
 
 
-# HEADER ONLY INSTALLATION
-# ===================================================
-install(
-  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN *.h
-  PATTERN "${FILELOG_EXCLUDE_FILE}" EXCLUDE
-  PATTERN "${TRACELOGGING_EXCLUDE_FILE}" EXCLUDE
-  PATTERN "${COLOREDCOUT_EXCLUDE_FILE}" EXCLUDE
-  )
+if ( CHOICE_INSTALL_G3SINKS )
+    # HEADER ONLY INSTALLATION
+    # ===================================================
+    install(
+      DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+      DESTINATION include
+      FILES_MATCHING
+      PATTERN *.h
+      PATTERN "${FILELOG_EXCLUDE_FILE}" EXCLUDE
+      PATTERN "${TRACELOGGING_EXCLUDE_FILE}" EXCLUDE
+      PATTERN "${COLOREDCOUT_EXCLUDE_FILE}" EXCLUDE
+      )
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  "g3snippetsVersion.cmake"
-  VERSION ${VERSION}
-  COMPATIBILITY AnyNewerVersion)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3snippetsVersion.cmake"
-        DESTINATION lib/cmake/g3sinks)
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+      "g3snippetsVersion.cmake"
+      VERSION ${VERSION}
+      COMPATIBILITY AnyNewerVersion)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3snippetsVersion.cmake"
+            DESTINATION lib/cmake/g3sinks)
+endif()

--- a/sink_syslog/CMakeLists.txt
+++ b/sink_syslog/CMakeLists.txt
@@ -44,32 +44,34 @@ target_include_directories(g3syslog
         $<INSTALL_INTERFACE:include>    
     )
 
-# INSTALLATION 
-# ===================================================
-install(TARGETS 
-           g3syslog
-	      EXPORT 
-            g3syslogTargets
-	      ARCHIVE DESTINATION lib
-	      LIBRARY DESTINATION lib
-	      INCLUDES DESTINATION include)
+if ( CHOICE_INSTALL_G3SINKS )
+    # INSTALLATION 
+    # ===================================================
+    install(TARGETS 
+               g3syslog
+    	      EXPORT 
+                g3syslogTargets
+    	      ARCHIVE DESTINATION lib
+    	      LIBRARY DESTINATION lib
+    	      INCLUDES DESTINATION include)
+    
+    install(EXPORT g3syslogTargets
+    	NAMESPACE G3::
+    	DESTINATION lib/cmake/g3sinks
+    	)
+    
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
+    	DESTINATION include
+    	FILES_MATCHING
+    	PATTERN *.h*
+    	)
 
-install(EXPORT g3syslogTargets
-	NAMESPACE G3::
-	DESTINATION lib/cmake/g3sinks
-	)
-
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/g3sinks"
-	DESTINATION include
-	FILES_MATCHING
-	PATTERN *.h*
-	)
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("g3syslogVersion.cmake"
-	VERSION ${VERSION}
-	COMPATIBILITY AnyNewerVersion
-	)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3syslogVersion.cmake"
-	DESTINATION lib/cmake/g3sinks
-	)
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file("g3syslogVersion.cmake"
+    	VERSION ${VERSION}
+    	COMPATIBILITY AnyNewerVersion
+    	)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g3syslogVersion.cmake"
+    	DESTINATION lib/cmake/g3sinks
+    	)
+endif()


### PR DESCRIPTION
The following error is observed when running cmake, this change attempts to avoid the overlapping target names.  Also attached is a minimal CMake + cpp that can be used to reproduce this.

```
CMake Error at build/_deps/g3sinks-src/CMakeLists.txt:112 (add_custom_target):
  add_custom_target cannot create target "clean-cmake" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory "/tmp/poc/build/_deps/g3log-src".  See
  documentation for policy CMP0002 for more details.
```

[poc.cpp.txt](https://github.com/KjellKod/g3sinks/files/10252629/poc.cpp.txt)
[CMakeLists.txt](https://github.com/KjellKod/g3sinks/files/10252630/CMakeLists.txt)

From looking at the CMake I'm using, there are likely a couple things I could be doing better or broke with the optional install  patch(es) but haven't looked into them yet.